### PR TITLE
chore: harden .fernignore (poetry.lock, .gitignore); export __version__ in __all__

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -3,6 +3,11 @@
 
 # PyPI distribution name (hedra-python) + project metadata; import name is `hedra`
 pyproject.toml
+# ...and the lockfile resolved against it (Fern's lock targets its own pyproject)
+poetry.lock
+
+# Local-dev ignores are hand-maintained
+.gitignore
 
 # README install/badge + usage use the hedra-python distribution name
 README.md

--- a/src/hedra/__init__.py
+++ b/src/hedra/__init__.py
@@ -179,6 +179,7 @@ __all__ = [
     "VoiceListResponse",
     "VoiceSummary",
     "WebhookPublicKey",
+    "__version__",
     "files",
     "keys",
     "models",


### PR DESCRIPTION
The first Fern Cloud regeneration PR rewrote the lockfile against Fern's
own pyproject and dropped the hand-maintained .gitignore entries; protect
both. Also completes the hand-patched version wiring (__all__ was missing
__version__, which the regen PR flagged).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
